### PR TITLE
chore: Migrate to graalvm/setup-graalvm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Set up GraalVM Native Image toolchain
-        uses: helpermethod/graalvm-native-image-toolchain@0.0.2
+      - name: Set up GraalVM and Native Image
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm-version: 21.3.0
+          version: 21.3.0
           java-version: 17
+          components: native-image
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -64,11 +66,13 @@ jobs:
         with:
           name: native-image-configuration
           path: target/classes/META-INF/native-image
-      - name: Set up GraalVM Native Image toolchain
-        uses: helpermethod/graalvm-native-image-toolchain@0.0.2
+      - name: Set up GraalVM and Native Image
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm-version: 21.3.0
+          version: 21.3.0
           java-version: 17
+          components: native-image
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Replaces helpermethod/graalvm-native-image-toolchain@0.0.2 with graalvm/setup-graalvm@v1.